### PR TITLE
fix: change the default image title

### DIFF
--- a/about/overview.html
+++ b/about/overview.html
@@ -14,7 +14,7 @@
    <h2>Course Staff</h2>
    <article class="teacher">
      <div class="teacher-image">
-       <img src="/static/images/pl-faculty.png" align="left" style="margin:0 20 px 0">
+       <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0">
      </div>
 
      <h3>Staff Member #1</h3>
@@ -23,7 +23,7 @@
 
    <article class="teacher">
      <div class="teacher-image">
-       <img src="/static/images/pl-faculty.png" align="left" style="margin:0 20 px 0">
+       <img src="/static/images/placeholder-faculty.png" align="left" style="margin:0 20 px 0">
      </div>
 
      <h3>Staff Member #2</h3>


### PR DESCRIPTION
The platform's default image title for staff is [placeholder-faculty.png](https://github.com/openedx/edx-platform/blob/master/common/static/images/placeholder-faculty.png). However, in the default course, the image link still has title **pl-faculty.png**. Because of this, the default image is not displayed on the About course page.
It is like this now:
![screen_1](https://user-images.githubusercontent.com/98233552/224414538-1fe16008-93c6-4026-aa53-285fb3e12940.png)

For any created course where an image has not been set for the staff:
![screen_2](https://user-images.githubusercontent.com/98233552/224414566-6da4eaa6-bdf5-4f1a-9205-1a11569b9f4e.png)

I manually tried to input the existing title of the image. Here's the result:
![screen_3](https://user-images.githubusercontent.com/98233552/224417037-2734ebdf-8482-45e6-a814-94f85b116826.png)
