### PR TITLE
docs: fix course/library keys in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,11 @@ This repository contains a course and some libraries that you can import into yo
      - Download
      - Source OLX
    * - *Open edX demo Course*
-     - ``course-v1:demo+Course+1``
+     - ``course-v1:Axim+demo_course+DemoX``
      - `<./dist/demo-course.tar.gz>`_
      - `<./demo-course>`_
    * - *Open edX Example Content Library*
-     - ``library-v1:demo+ContentLibrary``
+     - ``library-v1:Dummy+RESP_Q1``
      - `<./dist/demo-content-library.tar.gz>`_
      - `<./demo-content-library>`_
 


### PR DESCRIPTION
This updates the README to show the correct course key and library key. Respectively, these are determined by the values on the first line of:

* https://github.com/openedx/openedx-demo-course/blob/master/demo-course/course/course.xml
* https://github.com/openedx/openedx-demo-course/blob/master/demo-content-library/library/library.xml

@sarina @jswope00 , while we're here, are you folks happy with locking in the keys `course-v1:Axim+demo_course+DemoX` and `library-v1:Dummy+RESP_Q1`? I ask only because we can easily change them now (by editing those two XML files), but as soon as people start using the new demo course, we won't be able to change them without disrupting peoples' progress in the course.